### PR TITLE
Have fewer includes in go plugins.

### DIFF
--- a/plugins/cloudtrail/cloudtrail.go
+++ b/plugins/cloudtrail/cloudtrail.go
@@ -26,8 +26,6 @@ package main
 
 // #cgo CFLAGS: -I${SRCDIR}/../../
 /*
-#include <stdlib.h>
-#include <inttypes.h>
 #include <plugin_info.h>
 */
 import "C"

--- a/plugins/dummy/dummy.go
+++ b/plugins/dummy/dummy.go
@@ -18,8 +18,6 @@ package main
 
 // #cgo CFLAGS: -I${SRCDIR}/../../
 /*
-#include <stdlib.h>
-#include <inttypes.h>
 #include <plugin_info.h>
 */
 import "C"

--- a/plugins/json/json.go
+++ b/plugins/json/json.go
@@ -22,8 +22,6 @@ package main
 
 // #cgo CFLAGS: -I${SRCDIR}/../../
 /*
-#include <stdlib.h>
-#include <inttypes.h>
 #include <plugin_info.h>
 */
 import "C"


### PR DESCRIPTION
plugin_info.h now includes the headers it needs itself, so no need to
include them here.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>